### PR TITLE
Fix the commit message from release-it & publish tag

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,7 +1,8 @@
 {
   "git": {
     "tag": false,
-    "push": false
+    "push": false,
+    "commitMessage": "chore: release v${version}"
   },
   "github": {
     "release": true


### PR DESCRIPTION
## Description

Fixes the commit message that release-it uses and create a new release on GH with the correct version tag

## Related Issue

If this PR addresses a specific issue, please link to it here.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
