### PR TITLE
Add prepare script and `dist` directory to published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,12 @@
     "url": "git+https://github.com/businessinsider/eslint-plugin-playwright-tagging.git"
   },
   "homepage": "https://github.com/businessinsider/eslint-plugin-playwright-tagging#readme",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup index.ts --format esm,cjs --dts",
+    "prepare": "npm run build",
     "release": "release-it",
     "release:beta": "npm version prerelease --preid=beta && npm publish --restricted",
     "test": "tsx --test tests/lib/rules/validate-tags-playwright.test.ts"


### PR DESCRIPTION
## Description

This pull request includes updates to the `package.json` file to prepare the package for distribution. The changes add a `files` field to specify which files should be included in the published package and introduce a `prepare` script to ensure the package is built before publishing.

Key changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R19-R24): Added a `files` field to include the `dist` directory in the published package.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R19-R24): Added a `prepare` script to run the build process automatically before publishing.

## Related Issue

If this PR addresses a specific issue, please link to it here.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
