### PR TITLE
ci: Add PR linter

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,5 +1,8 @@
 name: PR Lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, edited, synchronize]

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -9,3 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: ytanikin/PRConventionalCommits@1.3.0
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          add_labels: 'true'

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -8,4 +8,4 @@ jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: ytanikin/PRConventionalCommits@v1.3.0
+      - uses: ytanikin/PRConventionalCommits@1.3.0

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,11 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ytanikin/PRConventionalCommits@v1.3.0


### PR DESCRIPTION
## Description

This pull request introduces a new GitHub Actions workflow to enforce pull request title conventions. The workflow ensures that PR titles adhere to conventional commit standards whenever a pull request is opened, edited, or synchronized.

New GitHub Actions workflow:

* [`.github/workflows/pr-lint.yml`](diffhunk://#diff-96c941d62860ad493e2ef6e2e641b5cdda1373729143a0a72a44f11f46895e4dR1-R11): Added a `PR Lint` workflow that triggers on pull request events (`opened`, `edited`, `synchronize`) and uses the `ytanikin/PRConventionalCommits@v1.3.0` action to validate PR titles.

## Related Issue

If this PR addresses a specific issue, please link to it here.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
